### PR TITLE
Prevent failure if no friendIconDownload function

### DIFF
--- a/lib/incoming/various.js
+++ b/lib/incoming/various.js
@@ -119,7 +119,7 @@ function getAvatar(avatarHash, iconChecksum, profileHash, username, context) {
   } else if (iconChecksum) {
     return context.getBuddyImage(iconChecksum);
   } else {
-    return context.friendIconDownload(username);
+    return context.friendIconDownload && context.friendIconDownload(username);
   }
 }
 


### PR DESCRIPTION
This doesn't fix the problem, but prevents the failure. If you tell me what `friendIconDownload` should do, I can PR a better fix for this.

Closes #9 
